### PR TITLE
TEL-3746 

### DIFF
--- a/src/python/grafana_canary.py
+++ b/src/python/grafana_canary.py
@@ -16,6 +16,9 @@ GRAFANA_USERNAME = "admin"
 GRAFANA_PASSWORD = response.get("Parameter").get("Value")
 GRAFANA_URL = os.getenv("GRAFANA_URL")
 GRAFANA_DASHBOARD_URL = os.getenv("GRAFANA_DASHBOARD_URL")
+SCREENSHOT_ON_STEP_START = os.getenv("SCREENSHOT_ON_STEP_START", False)
+SCREENSHOT_ON_STEP_SUCCESS = os.getenv("SCREENSHOT_ON_STEP_SUCCESS", False)
+SCREENSHOT_ON_STEP_FAILURE = os.getenv("SCREENSHOT_ON_STEP_FAILURE", True)
 
 TIMEOUT_SECONDS = 10
 
@@ -35,9 +38,9 @@ async def main():
     # Set synthetics configuration
     synthetics_configuration.set_config(
         {
-            "screenshot_on_step_start": False,
-            "screenshot_on_step_success": True,
-            "screenshot_on_step_failure": True,
+            "screenshot_on_step_start": SCREENSHOT_ON_STEP_START,
+            "screenshot_on_step_success": SCREENSHOT_ON_STEP_SUCCESS,
+            "screenshot_on_step_failure": SCREENSHOT_ON_STEP_FAILURE,
         }
     )
 


### PR DESCRIPTION
What did we do?
--

1. Use env_vars to set the behaviour of capturing screenshots
2. Stop capturing successful steps

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-3746

Evidence of work
--

1.

Next Steps
--

1. Rollout new version into lab01 and test
1.1. By default we do not capture screenshots on successful steps   
1.2. By default we do capture screenshots of failed steps
1.3. When SCREENSHOT_ON_STEP_SUCCESS is set to true we also get screenshots of the successful steps
1.4. We do not capture screenshots at the start

Risks
--

Collaboration
--

Co-authored-by: Gavin Davies <gavD@users.noreply.github.com>

