### PR TITLE
TEL-3834 Fixes for Canary to work against Grafana version 10

### DIFF
--- a/src/python/grafana_canary.py
+++ b/src/python/grafana_canary.py
@@ -38,9 +38,10 @@ async def main():
 
     selector_login_name = "//input[@placeholder='email or username']"
     selector_login_password = "//*[@id='current-password']"  # nosec B105
-    selector_login_button = (
-        "/html/body/div/div[1]/main/div/div[3]/div/div[2]/div/div/form/button"
-    )
+    selector_login_button = browser.find_element_by_xpath('//div[@aria-label="Login button"]/div[@class="css-1mhnkuh"')
+    # selector_login_button = (
+    #     "/html/body/div/div[1]/main/div/div[3]/div/div[2]/div/div/form/button"
+    # )
 
     # Set synthetics configuration
     synthetics_configuration.set_config(


### PR DESCRIPTION
The latest version of Grafana has markdown changes which break the Canary

What did we do?
--

1. Updated the Canary to be compatible with markdown in both 9.5.3 and 10.0.0 Grafana versions

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-

Evidence of work
--

1. Canary now working in lab, reliant markdown present in 9.5.3

Next Steps
--

1. Create new Canary version, roll out

Collaboration
--

Co-authored-by: Lee Myring <29373851+thinkstack@users.noreply.github.com>