### PR TITLE
TEL-4191 Adds support for Grafana v10.2.3

### DIFF
--- a/src/python/grafana_canary.py
+++ b/src/python/grafana_canary.py
@@ -36,9 +36,11 @@ async def main():
     browser = syn_webdriver.Chrome()
     browser.set_viewport_size(1024, 768)
 
-    selector_login_button = "//*[@aria-label='Login button']"
+    selector_login_button = "//button[normalize-space()='Log in']"
     selector_login_name = "//*[@placeholder='email or username']"
-    selector_login_password = "//*[@id='current-password']"  # nosec B105
+    selector_login_password = (
+        "//*[@id='current-password' or @name='password']"  # nosec B105
+    )
 
     # Set synthetics configuration
     synthetics_configuration.set_config(


### PR DESCRIPTION
What did we do?
--

1. Grafana has gone from Grafana v10.2.2 to Grafana v10.2.3 (1e84fede54)
2. The canary failed once mdtp-integration was updated. Faults were:
    a. `selenium.common.exceptions.NoSuchElementException: Message: no such element: Unable to locate element: {"method":"xpath","selector":"//*[@placeholder='email or username']"}` 
    b. `selenium.common.exceptions.NoSuchElementException: Message: no such element: Unable to locate element: {"method":"xpath","selector":"//*[@aria-label='Login button']"}`

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-4191

Evidence of work
--

1. Tested in mdtp-development (old version v10.2.2) with new code ✅ 
2. Tested in mdtp-integration (old version v10.2.3) with new code ✅  

This patch works on BOTH configurations, so the canaries should not fail during the Grafana rollout.

Next Steps
--

1. Wait for Terraform to complete
2. Continue the Grafana rollout

Risks
--

None known

Collaboration
--

Co-authored by: Stephen Palfreyman <18111914+sjpalf@users.noreply.github.com>
