### PR TITLE
TEL-4239 Adds support for Selenium 2.0 by updating API calls

### DIFF
--- a/src/python/grafana_canary.py
+++ b/src/python/grafana_canary.py
@@ -5,7 +5,7 @@ import boto3
 from aws_synthetics.common import synthetics_configuration
 from aws_synthetics.common import synthetics_logger as logger
 from aws_synthetics.selenium import synthetics_webdriver as syn_webdriver
-
+from selenium.webdriver.common.by import By
 
 SSM_PARAM = "/secrets/grafana/admin_password"
 
@@ -64,13 +64,13 @@ async def main():
     # Execute customer steps
     def customer_actions_1():
         logger.debug("Enter username")
-        browser.find_element_by_xpath(selector_login_name).send_keys(GRAFANA_USERNAME)
+        browser.find_element(By.XPATH, selector_login_name).send_keys(GRAFANA_USERNAME)
 
     await syn_webdriver.execute_step("input", customer_actions_1)
 
     def customer_actions_2():
         logger.debug("Enter password")
-        browser.find_element_by_xpath(selector_login_password).send_keys(
+        browser.find_element(By.XPATH, selector_login_password).send_keys(
             GRAFANA_PASSWORD
         )
 
@@ -78,13 +78,13 @@ async def main():
 
     def customer_actions_3():
         logger.debug("Click to login")
-        browser.find_element_by_xpath(selector_login_button).click()
+        browser.find_element(By.XPATH, selector_login_button).click()
 
     await syn_webdriver.execute_step("redirection", customer_actions_3)
     await syn_webdriver.execute_step("navigateToUrl", navigate_to_page_two)
 
     def customer_actions_4():
-        browser.find_element_by_class_name("main-view")
+        browser.find_element(By.CLASS_NAME, "main-view")
 
     await syn_webdriver.execute_step("click", customer_actions_4)
     logger.info("Canary successfully executed")


### PR DESCRIPTION
What did we do?
--

1. Given the task is to use Selenium 2, syn-python-selenium-2.0, we need to use the By helper class instead of explicit function calls

References
--

1. https://jira.tools.tax.service.gov.uk/browse/TEL-4239
2. Equivalent PR for Kibana https://github.com/hmrc/aws-canary-telemetry-kibana/pull/26
3. Equivalent PR for grafana-alerting https://github.com/hmrc/aws-canary-telemetry-grafana-alerting/pull/3

Evidence of work
--

It goes blue again once I made the code update:
![image](https://github.com/hmrc/aws-canary-telemetry-grafana/assets/205245/12c918ae-88c6-41fd-b44c-1c48c15144ef)

Next Steps
--

1. Deploy this, and its kibana and grafana-alerting equivalents
4. In `telemetry-trerraform`, update to `syn-python-selenium-2.0`

Risks
--

1. Will this work with non-updated `syn-python-selenium-1.3`
    a. Yes, I have tested this

Collaboration
--

1. Co-authored-by: Jonny Heywood <60072280+jonnydh@users.noreply.github.com>
